### PR TITLE
support google analytics 4

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,3 @@
  {{ with .Site.Author.linkedinurl }} || <a href="{{ . }}">LinkedIn</a> {{ end }}
  {{ with .Site.Author.email }} || {{ . }} {{ end }}
 </footer>
-
-{{ if not .Site.IsServer }}
-	{{ template "_internal/google_analytics_async.html" . }}
-{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,4 +1,7 @@
 <head>
+    {{ if not .Site.IsServer }}
+        {{ template "_internal/google_analytics.html" . }}
+    {{ end }}
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ with .Title }}{{ . }}{{ else }}{{ .Site.Title }}{{end}}</title>


### PR DESCRIPTION
based on this : [ronu-hugo-theme](https://github.com/softwareyoga/ronu-hugo-theme)


The async template is not suitable for Google Analytics 4.

the the google instructions is to:

> Below is the Google tag for this account. Copy and paste it in the code of every page of your website, immediately after the <head> element. Don’t add more than one Google tag to each page.
